### PR TITLE
🔧 Configure GraphQL Playground

### DIFF
--- a/app/views/graphql_playground/rails/application/index.html.erb
+++ b/app/views/graphql_playground/rails/application/index.html.erb
@@ -48,7 +48,9 @@
 
     GraphQLPlayground.init(root, {
       "endpoint": "<%= get_endpoint_url %>",
-      "canSaveConfig": false
+			"settings": {
+				"request.credentials": "include"
+			}
     });
   });
 </script>

--- a/app/views/layouts/graphql_playground/rails/application.html.erb
+++ b/app/views/layouts/graphql_playground/rails/application.html.erb
@@ -2,7 +2,6 @@
 <html>
 <head>
   <%= csrf_meta_tags %>
-  <%= csp_meta_tag %>
   <meta charset=utf-8 />
   <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
   <link rel="shortcut icon" href="https://graphcool-playground.netlify.com/favicon.png">


### PR DESCRIPTION
Removes the `csp_meta_tag` since we don't provide that on this route.

Configures request credentials to `include` to pass auth cookies.

Added in https://github.com/doximity/doximity/pull/26830